### PR TITLE
fix:a compile bug in example/snake

### DIFF
--- a/function.mbt
+++ b/function.mbt
@@ -55,7 +55,7 @@ pub fn blit(
   height : Int,
   flags : BlitFlag,
 ) -> Unit {
-  blit_ffi(get_addr(self.inner()), x, y, width, height, flags.to_int())
+  blit_ffi(get_addr(self.0), x, y, width, height, flags.to_int())
   ignore(self)
 }
 
@@ -77,7 +77,7 @@ pub fn blit_sub(
   flags : BlitFlag,
 ) -> Unit {
   blit_sub_ffi(
-    get_addr(self.inner()),
+    get_addr(self.0),
     x,
     y,
     width,

--- a/memory.mbt
+++ b/memory.mbt
@@ -17,7 +17,7 @@ struct Color(UInt)
 
 ///|
 pub fn rgb(color : UInt) -> Color {
-  color
+  Color(color)
 }
 
 ///| Sets the color of the palette at the given index.
@@ -26,12 +26,11 @@ pub fn rgb(color : UInt) -> Color {
 /// @param color the color to set
 pub fn set_palette(index : UInt, color : Color) -> Unit {
   if index == 0 || index > 4 {
-    trace("Palette index out of range")
     panic()
   }
   store_i32(
     address_PALETTE + (index.reinterpret_as_int() - 1) * 4,
-    color.inner().reinterpret_as_int(),
+    color.0.reinterpret_as_int(),
   )
 }
 


### PR DESCRIPTION
I tried to compile and run the snake example on Macos with the latest moonbit compiler(v0.6.24+012953835).
But i found some errors while compling.
```moonbit
Error: [4021]
    ╭─[ /Users/kelei/opensource/wasm4/function.mbt:22:3 ]
    │
 22 │   Sprite(bytes)
    │   ───┬──  
    │      ╰──── The value identifier Sprite is unbound.
────╯
Error: [4015]
    ╭─[ /Users/kelei/opensource/wasm4/function.mbt:60:26 ]
    │
 60 │   blit_ffi(get_addr(self.inner()), x, y, width, height, flags.to_int())
    │                          ──┬──  
    │                            ╰──── Type Sprite has no method inner.
────╯
Error: [4015]
    ╭─[ /Users/kelei/opensource/wasm4/function.mbt:82:19 ]
    │
 82 │     get_addr(self.inner()),
    │                   ──┬──  
    │                     ╰──── Type Sprite has no method inner.
────╯
error: failed to run build for target Wasm`
```
I think these may due to moonbit upgrade according to [moonbit 月报](https://www.moonbitlang.cn/weekly-updates/2025/08/11/index)

Please review my PR and consider to merge if it is helpful.