### PR TITLE
Fix deprecated warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 .mooncakes/
 .moonbit-lsp.json
+
+_build/
+target

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -2,61 +2,61 @@
 package "moonbitlang/wasm4"
 
 // Values
-fn disk_read(FixedArray[Byte], UInt) -> Int
+pub fn disk_read(FixedArray[Byte], UInt) -> Int
 
-fn disk_write(FixedArray[Byte], UInt) -> Int
+pub fn disk_write(FixedArray[Byte], UInt) -> Int
 
-fn get_draw_colors(UInt) -> UInt
+pub fn get_draw_colors(UInt) -> UInt
 
-fn get_frame_buffer(UInt) -> UInt
+pub fn get_frame_buffer(UInt) -> UInt
 
-fn get_gamepad(index? : UInt) -> GamePad
+pub fn get_gamepad(index? : UInt) -> GamePad
 
-fn get_mouse() -> Mouse
+pub fn get_mouse() -> Mouse
 
-fn get_netplay() -> Netplay
+pub fn get_netplay() -> Netplay
 
-fn get_palette(UInt) -> Color
+pub fn get_palette(UInt) -> Color
 
-fn get_system_hide_gamepad_overlay() -> Bool
+pub fn get_system_hide_gamepad_overlay() -> Bool
 
-fn get_system_preserve_framebuffer() -> Bool
+pub fn get_system_preserve_framebuffer() -> Bool
 
-fn hline(Int, Int, Int) -> Unit
+pub fn hline(Int, Int, Int) -> Unit
 
-fn line(Int, Int, Int, Int) -> Unit
+pub fn line(Int, Int, Int, Int) -> Unit
 
-fn oval(Int, Int, Int, Int) -> Unit
+pub fn oval(Int, Int, Int, Int) -> Unit
 
-fn rect(Int, Int, Int, Int) -> Unit
+pub fn rect(Int, Int, Int, Int) -> Unit
 
-fn rgb(UInt) -> Color
+pub fn rgb(UInt) -> Color
 
-let screen_height : UInt
+pub let screen_height : UInt
 
-let screen_width : UInt
+pub let screen_width : UInt
 
-fn set_draw_colors(UInt, index? : UInt) -> Unit
+pub fn set_draw_colors(UInt, index? : UInt) -> Unit
 
-fn set_frame_buffer(UInt, UInt) -> Unit
+pub fn set_frame_buffer(UInt, UInt) -> Unit
 
-fn set_palette(UInt, Color) -> Unit
+pub fn set_palette(UInt, Color) -> Unit
 
-fn set_system_hide_gamepad_overlay(Bool) -> Unit
+pub fn set_system_hide_gamepad_overlay(Bool) -> Unit
 
-fn set_system_preserve_framebuffer(Bool) -> Unit
+pub fn set_system_preserve_framebuffer(Bool) -> Unit
 
-fn sprite(FixedArray[Byte]) -> Sprite
+pub fn sprite(FixedArray[Byte]) -> Sprite
 
-fn text(String, Int, Int) -> Unit
+pub fn text(String, Int, Int) -> Unit
 
-fn tone((UInt, UInt), ADSR, ADSRVolume, ToneFlag) -> Unit
+pub fn tone((UInt, UInt), ADSR, ADSRVolume, ToneFlag) -> Unit
 
-fn tone_note_mode((Note, Note?), ADSR, ADSRVolume, ToneFlag) -> Unit
+pub fn tone_note_mode((Note, Note?), ADSR, ADSRVolume, ToneFlag) -> Unit
 
-fn trace(String) -> Unit
+pub fn trace(String) -> Unit
 
-fn vline(Int, Int, Int) -> Unit
+pub fn vline(Int, Int, Int) -> Unit
 
 // Errors
 
@@ -67,13 +67,13 @@ pub struct ADSR {
   decay : UInt
   attack : UInt
 }
-fn ADSR::new(UInt, release? : UInt, decay? : UInt, attack? : UInt) -> Self
+pub fn ADSR::new(UInt, release? : UInt, decay? : UInt, attack? : UInt) -> Self
 
 pub struct ADSRVolume {
   sustain : UInt
   peak : UInt
 }
-fn ADSRVolume::new(UInt, peak? : UInt) -> Self
+pub fn ADSRVolume::new(UInt, peak? : UInt) -> Self
 
 pub(all) struct BlitFlag {
   one_bit_per_pixel : Bool
@@ -92,8 +92,8 @@ pub struct GamePad {
   button_up : Bool
   button_down : Bool
 }
-impl Default for GamePad
-impl Eq for GamePad
+pub impl Default for GamePad
+pub impl Eq for GamePad
 
 pub struct Mouse {
   x : Int
@@ -102,8 +102,8 @@ pub struct Mouse {
   middle : Bool
   right : Bool
 }
-impl Default for Mouse
-impl Eq for Mouse
+pub impl Default for Mouse
+pub impl Eq for Mouse
 
 pub struct Netplay {
   index : UInt
@@ -114,11 +114,11 @@ pub struct Note {
   note : UInt
   bend : UInt
 }
-fn Note::new(UInt, bend? : UInt) -> Self
+pub fn Note::new(UInt, bend? : UInt) -> Self
 
 type Sprite
-fn Sprite::blit(Self, Int, Int, Int, Int, BlitFlag) -> Unit
-fn Sprite::blit_sub(Self, Int, Int, Int, Int, Int, Int, Int, BlitFlag) -> Unit
+pub fn Sprite::blit(Self, Int, Int, Int, Int, BlitFlag) -> Unit
+pub fn Sprite::blit_sub(Self, Int, Int, Int, Int, Int, Int, Int, BlitFlag) -> Unit
 
 pub(all) enum ToneChannel {
   Pulse1
@@ -132,7 +132,7 @@ pub struct ToneFlag {
   mode : ToneMode
   pan : TonePan
 }
-fn ToneFlag::new(channel? : ToneChannel, mode? : ToneMode, pan? : TonePan) -> Self
+pub fn ToneFlag::new(channel? : ToneChannel, mode? : ToneMode, pan? : TonePan) -> Self
 
 pub(all) enum ToneMode {
   Duty_1_8


### PR DESCRIPTION
Automated cleanup to eliminate warnings under `--warn-list @deprecated`.